### PR TITLE
ci(publish): switch NuGet publishing to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -2,20 +2,49 @@ name: Build and push nuget to registry
 
 on:
   workflow_dispatch:
-  
-jobs:
-  Build_base:
-    if: ${{ github.repository_owner == 'nittin-cz' }}
-    uses: ./.github/workflows/ci.yml
-    with:
-      package-id: XperienceCommunity.Localization.Base
-    secrets:
-      nuget_api_key: ${{ secrets.NUGET_API_KEY }}
 
-  Build_localization:
+env:
+  VERSION:
+
+jobs:
+  Build_and_publish:
     if: ${{ github.repository_owner == 'nittin-cz' }}
-    uses: ./.github/workflows/ci.yml
-    with:
-      package-id: XperienceCommunity.Localization
-    secrets:
-      nuget_api_key: ${{ secrets.NUGET_API_KEY }}
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      matrix:
+        package-id:
+          - XperienceCommunity.Localization.Base
+          - XperienceCommunity.Localization
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v4
+
+      - name: Get version from Directory.build.props
+        id: get_version
+        run: |
+          VERSION=$(grep -oP '(?<=<VersionPrefix>).*(?=</VersionPrefix>)' Directory.Build.props)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "Version found: $VERSION"
+
+      - name: Setup .NET 8.x
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: "8.x"
+
+      - name: Package the project
+        run: |
+          dotnet pack "src/${{ matrix.package-id }}/${{ matrix.package-id }}.csproj" -p:Version=${{ env.VERSION }} --configuration Release
+
+      - name: NuGet login (OIDC -> short-lived API key)
+        uses: NuGet/login@v1
+        id: nuget_login
+        with:
+          user: NITTIN
+
+      - name: Publish the package
+        run: |
+          dotnet nuget push "src/${{ matrix.package-id }}/bin/Release/${{ matrix.package-id }}.${{ env.VERSION }}.nupkg" --api-key ${{ steps.nuget_login.outputs.NUGET_API_KEY }} --source "https://api.nuget.org/v3/index.json"

--- a/docs/Releasing-NuGet-Packages.md
+++ b/docs/Releasing-NuGet-Packages.md
@@ -36,16 +36,29 @@ triggered GitHub Actions workflow — there is no automatic release-on-merge.
    - Select **Build and push nuget to registry** in the left sidebar.
    - Click **Run workflow**, choose the `main` branch, and confirm.
 
-   The workflow runs two jobs in parallel — one per package (`XperienceCommunity.Localization.Base`
-   and `XperienceCommunity.Localization`) — each of which:
+   The workflow runs one job per package (`XperienceCommunity.Localization.Base` and
+   `XperienceCommunity.Localization`, via a build matrix) in the `production` GitHub environment.
+   Each matrix run:
 
    - Reads the version from `Directory.Build.props`.
    - Runs `dotnet pack` for the package's `.csproj` in `Release` configuration.
-   - Publishes the resulting `.nupkg` to [nuget.org](https://www.nuget.org) using the
-     `NUGET_API_KEY` repository secret.
+   - Publishes the resulting `.nupkg` to [nuget.org](https://www.nuget.org) using
+     [NuGet Trusted Publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing)
+     (the `NuGet/login@v1` action, which exchanges the workflow's GitHub OIDC token for a
+     short-lived nuget.org API key — **no long-lived API key secret is stored in the repository**).
 
    Only repository owner `nittin-cz` can trigger this workflow (enforced by an `if:` condition in
-   the workflow), and it requires the `NUGET_API_KEY` secret to be configured on the repository.
+   the workflow). Publishing requires:
+
+   - A [Trusted Publishing policy](https://www.nuget.org/account/trustedpublishing) configured on
+     the `NITTIN` nuget.org account for this exact repository, workflow file
+     (`build_and_publish.yml`), and the `production` environment.
+   - The `production` environment to exist in the repository's **Settings → Environments** (GitHub
+     Actions creates it automatically the first time a workflow references it, if it isn't there
+     already).
+
+   This replaced an older setup that pushed with a static `NUGET_API_KEY` repository secret; see
+   [issue troubleshooting](#troubleshooting) below if you hit an old reference to that secret.
 
 4. **Verify the published packages.**
    Check [nuget.org/packages/XperienceCommunity.Localization](https://www.nuget.org/packages/XperienceCommunity.Localization)
@@ -80,7 +93,14 @@ does **not** publish anything — it's only useful to catch packaging errors ear
 
 - **Workflow fails at the "Get version" step** — `Directory.Build.props` must contain a
   `<VersionPrefix>X.Y.Z</VersionPrefix>` line; the workflow extracts it with a regex.
-- **`dotnet nuget push` fails with 403** — the `NUGET_API_KEY` secret is missing, expired, or
-  lacks push permission for these package IDs on nuget.org.
+- **`NuGet login` step fails / no token issued** — the job must have `permissions: id-token: write`
+  and run under the `production` GitHub environment, matching the Trusted Publishing policy
+  exactly (repository owner, repository name, workflow filename, environment). Check the policy at
+  [nuget.org/account/trustedpublishing](https://www.nuget.org/account/trustedpublishing) under the
+  `NITTIN` account.
+- **`dotnet nuget push` fails with 403** — the short-lived key from the login step expires quickly
+  (~1 hour); make sure the push step runs right after the login step. If the Trusted Publishing
+  policy itself doesn't grant push rights for a package ID (glob pattern), the login step's issued
+  key won't be able to push it.
 - **Version already exists on nuget.org** — nuget.org does not allow re-publishing the same
   version; bump `VersionPrefix` again and re-run the workflow.


### PR DESCRIPTION
## Summary
- The `NUGET_API_KEY` repository secret used by `build_and_publish.yml` was invalid/expired, blocking the `2.0.2` release (`403 Forbidden` from `dotnet nuget push`).
- Switches to [NuGet Trusted Publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing): a Trusted Publishing policy for this exact repo/workflow/environment already exists on nuget.org under the `NITTIN` account, so the workflow now exchanges a GitHub OIDC token for a short-lived (~1h) push key via `NuGet/login@v1`, instead of relying on a long-lived secret.
- Consolidated the two `uses: ./.github/workflows/ci.yml` reusable-workflow calls (`Build_base` / `Build_localization`) into a single job with a build matrix directly in `build_and_publish.yml`, so the OIDC subject matches the nuget.org policy exactly (workflow file `build_and_publish.yml`, environment `production`).
- Updated `docs/Releasing-NuGet-Packages.md` to describe the new flow and its troubleshooting steps.

## Notes
- `.github/workflows/ci.yml` is no longer referenced by anything (I couldn't remove it in this environment); it's now dead and can be deleted in a follow-up. The README's "CI: Build and Test" badge still points at it.
- The GitHub `production` environment must exist under **Settings → Environments** (created automatically on first run if missing) and match the nuget.org policy.
- The `user: NITTIN` value in the workflow is the nuget.org account name that owns the Trusted Publishing policy — public information, not a secret.

## Test plan
- [x] Workflow YAML reviewed for correct `permissions`, `environment`, and step ordering (login before push).
- [ ] First real run on `main` after merge — please trigger **Actions → Build and push nuget to registry → Run workflow** and confirm both matrix legs (`XperienceCommunity.Localization.Base`, `XperienceCommunity.Localization`) push `2.0.2` successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)