### PR TITLE
feat(admin): add translation-status filter and listing indicator

### DIFF
--- a/examples/DancingGoat/packages.lock.json
+++ b/examples/DancingGoat/packages.lock.json
@@ -1232,7 +1232,7 @@
         "type": "Project",
         "dependencies": {
           "Kentico.Xperience.Admin": "[31.8.1, )",
-          "XperienceCommunity.Localization.Base": "[2.0.1, )"
+          "XperienceCommunity.Localization.Base": "[2.0.2, )"
         }
       },
       "xperiencecommunity.localization.base": {

--- a/src/XperienceCommunity.Localization/Admin/Client/src/templates/TranslationStatusTableCellComponent.tsx
+++ b/src/XperienceCommunity.Localization/Admin/Client/src/templates/TranslationStatusTableCellComponent.tsx
@@ -1,0 +1,54 @@
+import Tooltip from '@mui/material/Tooltip';
+import React from 'react';
+import { MdCheckCircle, MdError, MdWarning } from 'react-icons/md';
+
+export type TranslationStatus = 'complete' | 'partial' | 'none';
+
+export interface TranslationStatusTableCellComponentProps {
+    status: TranslationStatus;
+    missingLanguageNames: string[];
+}
+
+const statusColorByStatus: Record<TranslationStatus, string> = {
+    complete: '#2e7d32',
+    partial: '#ed6c02',
+    none: '#d32f2f',
+};
+
+const StatusIcon = ({ status }: { status: TranslationStatus }): JSX.Element => {
+    const color = statusColorByStatus[status];
+
+    if (status === 'complete') {
+        return <MdCheckCircle color={color} size={18} />;
+    }
+
+    if (status === 'partial') {
+        return <MdWarning color={color} size={18} />;
+    }
+
+    return <MdError color={color} size={18} />;
+};
+
+const getTooltipText = (props: TranslationStatusTableCellComponentProps): string => {
+    if (props.status === 'complete') {
+        return 'All languages translated';
+    }
+
+    if (props.status === 'none') {
+        return 'No translations';
+    }
+
+    return `Missing: ${props.missingLanguageNames.join(', ')}`;
+};
+
+export const TranslationStatusTableCellComponent = (
+    props: TranslationStatusTableCellComponentProps,
+): JSX.Element => {
+    return (
+        <Tooltip title={getTooltipText(props)}>
+            <span style={{ display: 'inline-flex', alignItems: 'center' }}>
+                <StatusIcon status={props.status} />
+            </span>
+        </Tooltip>
+    );
+};

--- a/src/XperienceCommunity.Localization/Admin/Client/src/templates/index.ts
+++ b/src/XperienceCommunity.Localization/Admin/Client/src/templates/index.ts
@@ -1,1 +1,2 @@
 export * from './LocalizationConfigurationFormComponent'
+export * from './TranslationStatusTableCellComponent'

--- a/src/XperienceCommunity.Localization/Admin/Components/TranslationStatusCellModel.cs
+++ b/src/XperienceCommunity.Localization/Admin/Components/TranslationStatusCellModel.cs
@@ -1,0 +1,8 @@
+namespace XperienceCommunity.Localization.Admin.Components;
+
+public sealed class TranslationStatusCellModel
+{
+    public string Status { get; set; } = "none";
+
+    public IEnumerable<string> MissingLanguageNames { get; set; } = [];
+}

--- a/src/XperienceCommunity.Localization/Admin/Filters/LocalizationListingFilterModel.cs
+++ b/src/XperienceCommunity.Localization/Admin/Filters/LocalizationListingFilterModel.cs
@@ -1,0 +1,17 @@
+using Kentico.Xperience.Admin.Base.Filters;
+using Kentico.Xperience.Admin.Base.FormAnnotations;
+
+namespace XperienceCommunity.Localization.Admin.Filters;
+
+public sealed class LocalizationListingFilterModel
+{
+    [DropDownComponent(
+        Label = "Translation status",
+        Placeholder = "All",
+        DataProviderType = typeof(TranslationStatusDropDownOptionsProvider),
+        Order = 1)]
+    [FilterCondition(
+        BuilderType = typeof(TranslationStatusWhereConditionBuilder),
+        ColumnName = nameof(LocalizationKeyInfo.LocalizationKeyItemId))]
+    public string TranslationStatus { get; set; } = string.Empty;
+}

--- a/src/XperienceCommunity.Localization/Admin/Filters/TranslationStatusDropDownOptionsProvider.cs
+++ b/src/XperienceCommunity.Localization/Admin/Filters/TranslationStatusDropDownOptionsProvider.cs
@@ -1,0 +1,39 @@
+using CMS.ContentEngine;
+using CMS.DataEngine;
+
+using Kentico.Xperience.Admin.Base.FormAnnotations;
+
+namespace XperienceCommunity.Localization.Admin.Filters;
+
+public sealed class TranslationStatusDropDownOptionsProvider(IInfoProvider<ContentLanguageInfo> contentLanguageInfoProvider) : IDropDownOptionsProvider
+{
+    public Task<IEnumerable<DropDownOptionItem>> GetOptionItems()
+    {
+        var languages = contentLanguageInfoProvider.Get()
+            .GetEnumerableTypedResult()
+            .OrderBy(language => language.ContentLanguageDisplayName)
+            .ToList();
+
+        var options = new List<DropDownOptionItem>();
+
+        foreach (var language in languages)
+        {
+            options.Add(new DropDownOptionItem
+            {
+                Value = $"translated:{language.ContentLanguageID}",
+                Text = $"Translated – {language.ContentLanguageDisplayName}"
+            });
+        }
+
+        foreach (var language in languages)
+        {
+            options.Add(new DropDownOptionItem
+            {
+                Value = $"missing:{language.ContentLanguageID}",
+                Text = $"Missing translation – {language.ContentLanguageDisplayName}"
+            });
+        }
+
+        return Task.FromResult<IEnumerable<DropDownOptionItem>>(options);
+    }
+}

--- a/src/XperienceCommunity.Localization/Admin/Filters/TranslationStatusWhereConditionBuilder.cs
+++ b/src/XperienceCommunity.Localization/Admin/Filters/TranslationStatusWhereConditionBuilder.cs
@@ -1,0 +1,41 @@
+using CMS.DataEngine;
+
+using Kentico.Xperience.Admin.Base.Filters;
+
+namespace XperienceCommunity.Localization.Admin.Filters;
+
+public sealed class TranslationStatusWhereConditionBuilder(IInfoProvider<LocalizationTranslationItemInfo> localizationTranslationItemInfoProvider) : IWhereConditionBuilder
+{
+    public Task<IWhereCondition> Build(string columnName, object value)
+    {
+        var whereCondition = new WhereCondition();
+
+        if (value is not string selectedValue || string.IsNullOrEmpty(selectedValue))
+        {
+            return Task.FromResult<IWhereCondition>(whereCondition);
+        }
+
+        var parts = selectedValue.Split(':', 2);
+
+        if (parts.Length != 2 || !int.TryParse(parts[1], out int languageId))
+        {
+            return Task.FromResult<IWhereCondition>(whereCondition);
+        }
+
+        var keyIdsWithTranslation = localizationTranslationItemInfoProvider.Get()
+            .WhereEquals(nameof(LocalizationTranslationItemInfo.LocalizationTranslationItemContentLanguageId), languageId)
+            .WhereNotEmpty(nameof(LocalizationTranslationItemInfo.LocalizationTranslationItemText))
+            .Column(nameof(LocalizationTranslationItemInfo.LocalizationTranslationItemLocalizationKeyItemId));
+
+        if (parts[0] == "missing")
+        {
+            whereCondition.WhereNotIn(columnName, keyIdsWithTranslation);
+        }
+        else
+        {
+            whereCondition.WhereIn(columnName, keyIdsWithTranslation);
+        }
+
+        return Task.FromResult<IWhereCondition>(whereCondition);
+    }
+}

--- a/src/XperienceCommunity.Localization/Admin/UIPages/LocalizationListingPage.cs
+++ b/src/XperienceCommunity.Localization/Admin/UIPages/LocalizationListingPage.cs
@@ -1,6 +1,13 @@
-﻿using Kentico.Xperience.Admin.Base;
+﻿using CMS.ContentEngine;
+using CMS.DataEngine;
 
+using Kentico.Xperience.Admin.Base;
+
+using XperienceCommunity.Localization.Admin.Components;
+using XperienceCommunity.Localization.Admin.Filters;
 using XperienceCommunity.Localization.Admin.UIPages;
+
+using LoadDataSettings = Kentico.Xperience.Admin.Base.LoadDataSettings;
 
 [assembly: UIPage(
     parentType: typeof(LocalizationApplicationPage),
@@ -12,9 +19,13 @@ using XperienceCommunity.Localization.Admin.UIPages;
 
 namespace XperienceCommunity.Localization.Admin.UIPages;
 
-public class LocalizationListingPage : ListingPage
+public class LocalizationListingPage(
+    IInfoProvider<ContentLanguageInfo> contentLanguageInfoProvider,
+    IInfoProvider<LocalizationTranslationItemInfo> localizationTranslationItemInfoProvider) : ListingPage
 {
     private string? _searchTerm;
+    private List<ContentLanguageInfo>? _languages;
+    private Dictionary<int, HashSet<int>>? _translatedLanguageIdsByKeyId;
 
     protected override string ObjectType => LocalizationKeyInfo.OBJECT_TYPE;
 
@@ -23,7 +34,16 @@ public class LocalizationListingPage : ListingPage
         PageConfiguration.ColumnConfigurations
             .AddColumn(nameof(LocalizationKeyInfo.LocalizationKeyItemId), "ID")
             .AddColumn(nameof(LocalizationKeyInfo.LocalizationKeyItemName), "Name", searchable: true)
-            .AddColumn(nameof(LocalizationKeyInfo.LocalizationKeyItemDescription), "Description", searchable: true);
+            .AddColumn(nameof(LocalizationKeyInfo.LocalizationKeyItemDescription), "Description", searchable: true)
+            .AddComponentColumn(
+                "TranslationStatus",
+                "@nittin/xperience-community-localization/TranslationStatus",
+                "Translations",
+                modelRetriever: (_, rowData) => GetTranslationStatus((int)rowData[nameof(LocalizationKeyInfo.LocalizationKeyItemId)]),
+                loadedExternally: true,
+                sortable: false);
+
+        PageConfiguration.FilterConfiguration.FormModel = new LocalizationListingFilterModel();
 
         PageConfiguration.QueryModifiers.AddModifier((query, settings) =>
         {
@@ -75,7 +95,53 @@ public class LocalizationListingPage : ListingPage
             );
         }
 
+        // Loaded once per request (not per row) and read from the "Translations" column's
+        // modelRetriever, which cannot itself run async DB queries per row.
+        _languages = contentLanguageInfoProvider.Get().GetEnumerableTypedResult().ToList();
+
+        _translatedLanguageIdsByKeyId = localizationTranslationItemInfoProvider.Get()
+            .WhereNotEmpty(nameof(LocalizationTranslationItemInfo.LocalizationTranslationItemText))
+            .Columns(
+                nameof(LocalizationTranslationItemInfo.LocalizationTranslationItemLocalizationKeyItemId),
+                nameof(LocalizationTranslationItemInfo.LocalizationTranslationItemContentLanguageId))
+            .GetEnumerableTypedResult()
+            .GroupBy(translation => translation.LocalizationTranslationItemLocalizationKeyItemId)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Select(translation => translation.LocalizationTranslationItemContentLanguageId).ToHashSet());
+
         return base.LoadData(settings, cancellationToken);
+    }
+
+    private TranslationStatusCellModel GetTranslationStatus(int keyId)
+    {
+        var languages = _languages ?? [];
+        var translatedLanguageIds = _translatedLanguageIdsByKeyId?.GetValueOrDefault(keyId) ?? [];
+
+        var missingLanguageNames = languages
+            .Where(language => !translatedLanguageIds.Contains(language.ContentLanguageID))
+            .Select(language => language.ContentLanguageDisplayName)
+            .ToList();
+
+        string status;
+        if (missingLanguageNames.Count == 0)
+        {
+            status = "complete";
+        }
+        else if (translatedLanguageIds.Count == 0)
+        {
+            status = "none";
+        }
+        else
+        {
+            status = "partial";
+        }
+
+        return new TranslationStatusCellModel
+        {
+            Status = status,
+            MissingLanguageNames = missingLanguageNames
+        };
     }
 
     [PageCommand]


### PR DESCRIPTION
## Summary

Follow-up to #31 (text search). Adds a more structured way to find keys by translation completeness:

- **Filter**: "Translation status" dropdown on the Localizations listing (uses Kentico's `PageConfiguration.FilterConfiguration.FormModel` / `FilterCondition` API). Options are generated per active content language ("Translated – Czech", "Missing translation – Czech", …). The condition is built as a `WhereIn`/`WhereNotIn` against a subquery of `LocalizationTranslationItemInfo` scoped to the selected language — an independent condition, not sharing the search feature's conditional LEFT JOIN, so it composes safely whether or not a search term is also active.
- **Listing column**: a "Translations" column showing one status icon (✅ complete / ⚠️ partial / ❌ none) with a tooltip listing missing languages, via a small new React table-cell component (`AddComponentColumn`).

## Design notes / trade-offs

- Translation completeness is computed with **one extra query per page load** (all translation rows with non-empty text, grouped by key), not scoped to just the visible page. `PageConfiguration.PageDataModifier` — the officially intended hook for per-page batch enrichment — turned out to be `internal` in `Kentico.Xperience.Admin.Base` 31.8.1, so it's not usable from an external module. The listing page instead caches the full completeness map instance-side in `LoadData` before calling `base.LoadData`, and the column's `modelRetriever` reads from that cache (same established pattern as PR #31's `_searchTerm` field).
- This is a reasonable cost for a translation-strings listing (expected to be up to low thousands of rows), but does not scale to a very large number of keys. Left a code comment noting the trade-off.
- Filter and search are independent code paths (different WHERE mechanisms) specifically so they don't interact/conflict when both are active at once.

## Test plan
- [x] `dotnet build` of the full solution (library + DancingGoat) succeeds with 0 errors/warnings.
- [x] Frontend `npm run build` (lint + webpack) succeeds with 0 errors/warnings.
- [x] Verified via decompilation (ilspycmd against the actual 31.8.1 `Kentico.Xperience.Admin` assemblies) that all APIs used (`FilterConfiguration.FormModel`, `FilterConditionAttribute`, `IWhereConditionBuilder`, `IDropDownOptionsProvider`, `WhereIn`/`WhereNotIn`, `AddComponentColumn`) exist with the exact signatures used here.
- [ ] Manual verification in a running admin (filter + icon/tooltip rendering) — not done in this environment (no live Xperience database available).