### PR TITLE
chore(dancinggoat): bump kentico.xperience.dbmanager to 31.8.1

### DIFF
--- a/examples/DancingGoat/.config/dotnet-tools.json
+++ b/examples/DancingGoat/.config/dotnet-tools.json
@@ -3,12 +3,11 @@
   "isRoot": true,
   "tools": {
     "kentico.xperience.dbmanager": {
-      "version": "29.5.3",
+      "version": "31.8.1",
       "commands": [
         "kentico-xperience-dbmanager"
-      ]
+      ],
+      "rollForward": false
     }
   }
 }
-
-


### PR DESCRIPTION
## Summary
- `examples/DancingGoat/.config/dotnet-tools.json` still pinned `kentico.xperience.dbmanager` to `29.5.3`, while the sample project's `Kentico.Xperience.*` packages were bumped to `31.8.1` in #33.
- Found this while creating a local test database to verify #33's fix end-to-end: the app refused to start with `The database version 'X' does not match the project version 'Y'` when the dbmanager tool version didn't match.

## Test plan
- [x] Created a fresh local SQL Server database with `dotnet kentico-xperience-dbmanager` at `31.8.1` and ran `DancingGoat` against it — the app now starts and matches the database version.