### PR TITLE
bump version to 2.1.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <Authors>$(Company) and Trevor Fayas</Authors>
     <Copyright>Copyright © $(Company) $([System.DateTime]::Now.Year)</Copyright>
     <Trademark>$(Company)™</Trademark>
-    <VersionPrefix>2.0.2</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
 
     <PackageProjectUrl>https://github.com/nittin-cz/xperience-community-localization</PackageProjectUrl>


### PR DESCRIPTION
## Summary
- Bumps `VersionPrefix` in `Directory.Build.props` from `2.0.2` to `2.1.0`.
- Minor bump (per [Releasing-NuGet-Packages.md](docs/Releasing-NuGet-Packages.md)) since this release only adds backwards-compatible functionality on top of `2.0.2`:
  - Search across localization keys and translations (#31)
  - "Translation status" listing filter + per-row completeness indicator (#36)

Ready to publish via the **Build and push nuget to registry** workflow after merge.