### PR TITLE
feat(admin): show translation values in the listing tooltip

### DIFF
--- a/src/XperienceCommunity.Localization/Admin/Client/src/templates/TranslationStatusTableCellComponent.tsx
+++ b/src/XperienceCommunity.Localization/Admin/Client/src/templates/TranslationStatusTableCellComponent.tsx
@@ -4,9 +4,15 @@ import { MdCheckCircle, MdError, MdWarning } from 'react-icons/md';
 
 export type TranslationStatus = 'complete' | 'partial' | 'none';
 
+export interface TranslationPreview {
+    languageName: string;
+    text: string;
+}
+
 export interface TranslationStatusTableCellComponentProps {
     status: TranslationStatus;
     missingLanguageNames: string[];
+    translations: TranslationPreview[];
 }
 
 const statusColorByStatus: Record<TranslationStatus, string> = {
@@ -29,23 +35,30 @@ const StatusIcon = ({ status }: { status: TranslationStatus }): JSX.Element => {
     return <MdError color={color} size={18} />;
 };
 
-const getTooltipText = (props: TranslationStatusTableCellComponentProps): string => {
-    if (props.status === 'complete') {
-        return 'All languages translated';
-    }
-
+const TooltipContent = (props: TranslationStatusTableCellComponentProps): JSX.Element => {
     if (props.status === 'none') {
-        return 'No translations';
+        return <span>No translations</span>;
     }
 
-    return `Missing: ${props.missingLanguageNames.join(', ')}`;
+    return (
+        <span>
+            {props.translations.map(translation => (
+                <div key={translation.languageName}>
+                    <strong>{translation.languageName}:</strong> {translation.text}
+                </div>
+            ))}
+            {props.missingLanguageNames.length > 0 && (
+                <div>Missing: {props.missingLanguageNames.join(', ')}</div>
+            )}
+        </span>
+    );
 };
 
 export const TranslationStatusTableCellComponent = (
     props: TranslationStatusTableCellComponentProps,
 ): JSX.Element => {
     return (
-        <Tooltip title={getTooltipText(props)}>
+        <Tooltip title={<TooltipContent {...props} />}>
             <span style={{ display: 'inline-flex', alignItems: 'center' }}>
                 <StatusIcon status={props.status} />
             </span>

--- a/src/XperienceCommunity.Localization/Admin/Components/TranslationStatusCellModel.cs
+++ b/src/XperienceCommunity.Localization/Admin/Components/TranslationStatusCellModel.cs
@@ -5,4 +5,13 @@ public sealed class TranslationStatusCellModel
     public string Status { get; set; } = "none";
 
     public IEnumerable<string> MissingLanguageNames { get; set; } = [];
+
+    public IEnumerable<TranslationPreviewModel> Translations { get; set; } = [];
+}
+
+public sealed class TranslationPreviewModel
+{
+    public string LanguageName { get; set; } = string.Empty;
+
+    public string Text { get; set; } = string.Empty;
 }

--- a/src/XperienceCommunity.Localization/Admin/UIPages/LocalizationListingPage.cs
+++ b/src/XperienceCommunity.Localization/Admin/UIPages/LocalizationListingPage.cs
@@ -23,9 +23,11 @@ public class LocalizationListingPage(
     IInfoProvider<ContentLanguageInfo> contentLanguageInfoProvider,
     IInfoProvider<LocalizationTranslationItemInfo> localizationTranslationItemInfoProvider) : ListingPage
 {
+    private const int TranslationPreviewMaxLength = 40;
+
     private string? _searchTerm;
     private List<ContentLanguageInfo>? _languages;
-    private Dictionary<int, HashSet<int>>? _translatedLanguageIdsByKeyId;
+    private Dictionary<int, Dictionary<int, string>>? _translationsByKeyId;
 
     protected override string ObjectType => LocalizationKeyInfo.OBJECT_TYPE;
 
@@ -99,16 +101,21 @@ public class LocalizationListingPage(
         // modelRetriever, which cannot itself run async DB queries per row.
         _languages = contentLanguageInfoProvider.Get().GetEnumerableTypedResult().ToList();
 
-        _translatedLanguageIdsByKeyId = localizationTranslationItemInfoProvider.Get()
+        _translationsByKeyId = localizationTranslationItemInfoProvider.Get()
             .WhereNotEmpty(nameof(LocalizationTranslationItemInfo.LocalizationTranslationItemText))
             .Columns(
                 nameof(LocalizationTranslationItemInfo.LocalizationTranslationItemLocalizationKeyItemId),
-                nameof(LocalizationTranslationItemInfo.LocalizationTranslationItemContentLanguageId))
+                nameof(LocalizationTranslationItemInfo.LocalizationTranslationItemContentLanguageId),
+                nameof(LocalizationTranslationItemInfo.LocalizationTranslationItemText))
             .GetEnumerableTypedResult()
             .GroupBy(translation => translation.LocalizationTranslationItemLocalizationKeyItemId)
             .ToDictionary(
                 group => group.Key,
-                group => group.Select(translation => translation.LocalizationTranslationItemContentLanguageId).ToHashSet());
+                // GroupBy-then-First (instead of a plain ToDictionary) tolerates duplicate
+                // (key, language) rows rather than throwing, since it isn't DB-enforced unique.
+                group => group
+                    .GroupBy(translation => translation.LocalizationTranslationItemContentLanguageId)
+                    .ToDictionary(g => g.Key, g => g.First().LocalizationTranslationItemText));
 
         return base.LoadData(settings, cancellationToken);
     }
@@ -116,11 +123,20 @@ public class LocalizationListingPage(
     private TranslationStatusCellModel GetTranslationStatus(int keyId)
     {
         var languages = _languages ?? [];
-        var translatedLanguageIds = _translatedLanguageIdsByKeyId?.GetValueOrDefault(keyId) ?? [];
+        var translations = _translationsByKeyId?.GetValueOrDefault(keyId) ?? [];
 
         var missingLanguageNames = languages
-            .Where(language => !translatedLanguageIds.Contains(language.ContentLanguageID))
+            .Where(language => !translations.ContainsKey(language.ContentLanguageID))
             .Select(language => language.ContentLanguageDisplayName)
+            .ToList();
+
+        var translationPreviews = languages
+            .Where(language => translations.ContainsKey(language.ContentLanguageID))
+            .Select(language => new TranslationPreviewModel
+            {
+                LanguageName = language.ContentLanguageDisplayName,
+                Text = Truncate(translations[language.ContentLanguageID], TranslationPreviewMaxLength)
+            })
             .ToList();
 
         string status;
@@ -128,7 +144,7 @@ public class LocalizationListingPage(
         {
             status = "complete";
         }
-        else if (translatedLanguageIds.Count == 0)
+        else if (translationPreviews.Count == 0)
         {
             status = "none";
         }
@@ -140,9 +156,13 @@ public class LocalizationListingPage(
         return new TranslationStatusCellModel
         {
             Status = status,
-            MissingLanguageNames = missingLanguageNames
+            MissingLanguageNames = missingLanguageNames,
+            Translations = translationPreviews
         };
     }
+
+    private static string Truncate(string value, int maxLength)
+        => value.Length <= maxLength ? value : string.Concat(value.AsSpan(0, maxLength), "…");
 
     [PageCommand]
     public override Task<ICommandResponse<RowActionResult>> Delete(int id) => base.Delete(id);


### PR DESCRIPTION
## Summary

Follow-up to #36, based on feedback after trying it in a live instance: the "Translations" status icon's tooltip now shows each language's actual translated value (truncated to 40 chars, e.g. "EN: Hello there…") instead of only naming missing languages.

- `LocalizationListingPage` now also selects `LocalizationTranslationItemText` in the same per-page-load batch query used for the completeness indicator (no extra query).
- `TranslationStatusCellModel` gains a `Translations` list of `{ LanguageName, Text }`.
- The React tooltip renders one line per translated language, plus a "Missing: …" line if any languages are still missing.

## Test plan
- [x] `dotnet build` (library + DancingGoat) — 0 errors/warnings.
- [x] `npm run build` (lint + webpack) — 0 errors/warnings.