### PR TITLE
bump version to 2.1.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <Authors>$(Company) and Trevor Fayas</Authors>
     <Copyright>Copyright © $(Company) $([System.DateTime]::Now.Year)</Copyright>
     <Trademark>$(Company)™</Trademark>
-    <VersionPrefix>2.1.0</VersionPrefix>
+    <VersionPrefix>2.1.1</VersionPrefix>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
 
     <PackageProjectUrl>https://github.com/nittin-cz/xperience-community-localization</PackageProjectUrl>


### PR DESCRIPTION
## Summary
- Bumps `VersionPrefix` from `2.1.0` to `2.1.1` (patch).
- New in this release: the "Translations" listing tooltip now shows each language's translated value (truncated to 40 chars), not just which languages are missing (#39).

Ready to publish via the **Build and push nuget to registry** workflow after merge.